### PR TITLE
Trait that enables attribute fixup before serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pm_to_blib*
 cover_db
 MANIFEST*
 !MANIFEST.SKIP
+/.project

--- a/lib/KiokuDB/Meta/Attribute/SetOnSave.pm
+++ b/lib/KiokuDB/Meta/Attribute/SetOnSave.pm
@@ -12,3 +12,42 @@ has 'setonsave' => (
 );
 
 1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+KiokuDB::Meta::Attribute::SetOnSave - Trait for automatically updating attributes before collapsing
+
+=head1 SYNOPSIS
+
+    # in your class:
+
+    package Foo;
+    use Moose;
+    use Class::Date 'now';
+
+    has bar => (
+        traits    => [qw(KiokuDB::SetOnSave)],
+        isa       => "Class::Date",
+        is        => "ro",
+        setonsave => sub { now }
+    );
+
+=head1 DESCRIPTION
+
+This L<Moose::Meta::Attribute> trait tells L<KiokuDB> to update an attribute before collapsing.
+
+=head1 ATTRIBUTES
+
+=over 4
+
+=item setonsave
+
+A method which will be invoked just before the object is collapsed. setonsave is invoked with
+the object as it's first parameter and the attribute is updated with the return value, similarly
+to default and builder methods. 
+
+=cut

--- a/lib/KiokuDB/Meta/Attribute/SetOnSave.pm
+++ b/lib/KiokuDB/Meta/Attribute/SetOnSave.pm
@@ -1,0 +1,14 @@
+package KiokuDB::Meta::Attribute::SetOnSave;
+use Moose::Role;
+
+use namespace::clean -except => 'meta';
+
+sub Moose::Meta::Attribute::Custom::Trait::KiokuDB::SetOnSave::register_implementation { __PACKAGE__ }
+
+has 'setonsave' => (
+    is        => 'rw',
+    isa       => 'CodeRef',
+    required  => 1,
+);
+
+1;

--- a/lib/KiokuDB/TypeMap/Entry/MOP.pm
+++ b/lib/KiokuDB/TypeMap/Entry/MOP.pm
@@ -551,6 +551,27 @@ better, so make use of L<Moose::Meta::Class/make_immutable>.
 
 If true the object will be collapsed as part of its parent, without an ID.
 
+=item before_collapse
+
+=item after_expand
+
+Optional callbacks, which are invoked before collapsing and after expanding
+an entry, respectively.
+
+The callbacks can either be CODEREFs or function names. The callbacks will be invoked
+with the object, which is about to be collapsed or has just been expanded, as it's 
+first argument.
+
+    KiokuDB::TypeMap->new(
+        entries => {
+            'My::Class' => KiokuDB::TypeMap::Entry::MOP->new(
+                before_collapse => 'log_saved_objects',
+                after_expand    => sub { $_[0]->some_attribute('foobar'); }
+            ),
+        },
+    );
+
+
 =item check_class_versions
 
 If true (the default) then class versions will be checked on load and if there

--- a/lib/KiokuDB/TypeMap/Entry/MOP.pm
+++ b/lib/KiokuDB/TypeMap/Entry/MOP.pm
@@ -49,11 +49,18 @@ has write_upgrades => (
     default => 0,
 );
 
+has [qw(before_collapse after_expand)] => (
+    is  => "ro",
+    isa => "Maybe[Str|CodeRef]",
+);
+
 # FIXME collapser and expaner should both be methods in Class::MOP::Class,
 # apart from the visit call
 
 sub compile_collapse_body {
     my ( $self, $class, @args ) = @_;
+
+    my $before_collapse = $self->before_collapse || sub {};
 
     my $meta = Class::MOP::get_metaclass_by_name($class);
 
@@ -152,6 +159,8 @@ sub compile_collapse_body {
                 }
             }
 
+            $object->$before_collapse;
+            
             my %collapsed;
 
             attr: foreach my $attr ( @attrs ) {
@@ -184,6 +193,13 @@ sub compile_collapse_body {
 sub compile_expand {
     my ( $self, $class, $resolver, @args ) = @_;
 
+    my $after_expand = $self->after_expand;
+    my $after_expand_wrapper = $self->after_expand ? sub {
+        my ($linker, $object) = @_;
+        $linker->load_queue;
+        $object->$after_expand;
+    } : sub {};
+
     my $meta = Class::MOP::get_metaclass_by_name($class);
 
     my $typemap_entry = $self;
@@ -196,6 +212,7 @@ sub compile_expand {
 
     return sub {
         my ( $linker, $entry, @args ) = @_;
+        my $object;
 
         if ( $entry->has_class_meta and !$anon ) {
             # the entry is for an anonymous subclass of this class, we need to
@@ -210,11 +227,13 @@ sub compile_expand {
             }
 
             my $method = $resolver->expand_method($anon_class);
-            return $linker->$method($entry, @args);
+            $object = $linker->$method($entry, @args);
+            $after_expand_wrapper->($linker, $object);
+            return $object;
         }
 
         if ( !$self->check_class_versions or $self->is_version_up_to_date($meta, $version, $entry->class_version) ) {
-            $linker->$inner($entry, @args);
+            $object=$linker->$inner($entry, @args);
         } else {
             my $upgraded = $self->upgrade_entry( linker => $linker, meta => $meta, entry => $entry, expand_args => \@args);
 
@@ -225,8 +244,11 @@ sub compile_expand {
                 $linker->backend->insert($upgraded);
             }
 
-            $linker->$inner($upgraded, @args);
+            $object=$linker->$inner($upgraded, @args);
         }
+        
+        $after_expand_wrapper->($linker, $object);
+        return $object;
     }
 }
 

--- a/lib/Moose/Meta/Attribute/Custom/Trait/KiokuDB/SetOnSave.pm
+++ b/lib/Moose/Meta/Attribute/Custom/Trait/KiokuDB/SetOnSave.pm
@@ -1,0 +1,7 @@
+#!/usr/bin/perl
+
+package Moose::Meta::Attribute::Custom::Trait::KiokuDB::SetOnSave;
+
+use KiokuDB::Meta::Attribute::SetOnSave;
+
+1;


### PR DESCRIPTION
A method which will be invoked just before the object is collapsed. `setonsave` is invoked with
the object as it's first parameter and the attribute is updated with the return value, similarly
to default and builder methods. 

Also, we have added the hooks `before_collapse` and `after_expand` for more serialization trickery.
