### PR TITLE
replace Class::MOP::load_class with Class::Load

### DIFF
--- a/lib/KiokuDB/Backend.pm
+++ b/lib/KiokuDB/Backend.pm
@@ -2,6 +2,7 @@ package KiokuDB::Backend;
 use Moose::Role;
 # ABSTRACT: Backend interface role
 
+use Class::Load ();
 use Moose::Util::TypeConstraints;
 use Try::Tiny;
 
@@ -13,10 +14,10 @@ coerce ( __PACKAGE__,
         my $class = delete $p{class} || die "Can't coerce backend from hash without a 'class' parameter";
 
         try {
-            Class::MOP::load_class("KiokuDB::Backend::$class");
+            Class::Load::load_class("KiokuDB::Backend::$class");
             "KiokuDB::Backend::$class"->new(%p);
         } catch {
-            Class::MOP::load_class($class);
+            Class::Load::load_class($class);
             $class->new(%p);
         };
     },

--- a/lib/KiokuDB/Backend/Serialize.pm
+++ b/lib/KiokuDB/Backend/Serialize.pm
@@ -2,6 +2,7 @@ package KiokuDB::Backend::Serialize;
 use Moose::Role;
 # ABSTRACT: Serialization role for backends
 
+use Class::Load ();
 use Moose::Util::TypeConstraints;
 
 use namespace::clean -except => 'meta';
@@ -18,13 +19,13 @@ my %types = (
 coerce( __PACKAGE__,
     from Str => via {
         my $class = $types{lc($_)};
-        Class::MOP::load_class($class);
+        Class::Load::load_class($class);
         $class->new;
     },
     from HashRef => via {
         my %args = %$_;
         my $class = $types{lc(delete $args{format})};
-        Class::MOP::load_class($class);
+        Class::Load::load_class($class);
         $class->new(%args);
     },
 );

--- a/lib/KiokuDB/Serializer.pm
+++ b/lib/KiokuDB/Serializer.pm
@@ -4,6 +4,7 @@ use Moose::Role;
 
 use Carp qw(croak);
 
+use Class::Load ();
 use Moose::Util::TypeConstraints;
 
 use namespace::clean -except => 'meta';
@@ -22,13 +23,13 @@ my %types = (
 coerce( __PACKAGE__,
     from Str => via {
         my $class = $types{lc($_)} or croak "unknown format: $_";;
-        Class::MOP::load_class($class);
+        Class::Load::load_class($class);
         $class->new;
     },
     from HashRef => via {
         my %args = %$_;
         my $class = $types{lc(delete $args{format})} or croak "unknown format: $args{format}";
-        Class::MOP::load_class($class);
+        Class::Load::load_class($class);
         $class->new(%args);
     },
 );

--- a/lib/KiokuDB/TypeMap/Composite.pm
+++ b/lib/KiokuDB/TypeMap/Composite.pm
@@ -2,6 +2,7 @@ package KiokuDB::TypeMap::Composite;
 use Moose::Role;
 # ABSTRACT: A role for KiokuDB::TypeMaps created out of many smaller typemaps
 
+use Class::Load ();
 use KiokuDB::TypeMap;
 
 use namespace::clean -except => 'meta';
@@ -63,7 +64,7 @@ sub _construct_entry {
     my $args = $self->_entry_options(@args);
 
     my $type = delete $args->{type};
-    Class::MOP::load_class($type);
+    Class::Load::load_class($type);
 
     $type->new($args);
 }

--- a/lib/KiokuDB/TypeMap/Entry/Closure.pm
+++ b/lib/KiokuDB/TypeMap/Entry/Closure.pm
@@ -4,6 +4,7 @@ use Moose;
 use Carp qw(croak);
 use Scalar::Util qw(refaddr);
 use PadWalker 1.9;
+use Class::Load ();
 
 no warnings 'recursion';
 
@@ -123,7 +124,7 @@ sub compile_expand {
                 if ( defined(my $file = $data->{file}) ) {
                     require $file unless exists $INC{$file};
                 } else {
-                    Class::MOP::load_class($data->{package});
+                    Class::Load::load_class($data->{package});
                 }
 
                 unless ( defined(*{$glob}{CODE}) ) {

--- a/lib/KiokuDB/Util.pm
+++ b/lib/KiokuDB/Util.pm
@@ -8,6 +8,7 @@ use Path::Class;
 use Carp qw(croak);
 use MooseX::YAML 0.04;
 use Scalar::Util qw(blessed);
+use Class::Load ();
 
 use namespace::clean;
 
@@ -50,7 +51,7 @@ sub dsn_to_backend {
         $moniker = $monikers{$moniker} || $moniker;
         my $class = "KiokuDB::Backend::$moniker";
 
-        Class::MOP::load_class($class);
+        Class::Load::load_class($class);
         return $class->new_from_dsn($rest, @args);
     } elsif ( my $args = _try_json($dsn) ) {
         my $dsn;
@@ -92,7 +93,7 @@ sub config_to_backend {
     return $backend if blessed($backend);
 
     my $backend_class = $backend->{class};
-    Class::MOP::load_class($backend_class);
+    Class::Load::load_class($backend_class);
 
     return $backend_class->new_from_dsn_params(
         ( defined($base) ? ( dir => $base->subdir("data") ) : () ),


### PR DESCRIPTION
Class::MOP::load_class is deprecated. This is a simple replacement for Class::Load::load_class.
