### PR TITLE
Update Search::GIN::Query::Class dep to 0.07

### DIFF
--- a/lib/KiokuDB/Test/Fixture/GIN/Class.pm
+++ b/lib/KiokuDB/Test/Fixture/GIN/Class.pm
@@ -5,7 +5,7 @@ use Test::More;
 use Test::Moose;
 use Scalar::Util qw(refaddr);
 
-use Search::GIN::Query::Class 0.03;
+use Search::GIN::Query::Class 0.07;
 
 use namespace::clean -except => 'meta';
 


### PR DESCRIPTION
The first version of this package on CPAN to actually declare a version is
0.07. The previous dependent version 0.03 didn't declare a version, and thus,
if we had that old version of Search::GIN, the loading in the tests would
fail.

I discovered this issue while trying to build a new KiokuDB on a an old system
that provided Search::GIN 0.04 (which is now on BackPAN).
